### PR TITLE
feat: soft delete endpoint for feature flags

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ linters:
   enable:
     - bodyclose
     - exportloopref
-    - gofumpt
     - goimports
     - gosec
     - gosimple

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,42 +1,49 @@
+run:
+  timeout: 5m
+  issues-exit-code: 1
+  tests: true
+  skip-dirs:
+    - local
+
+issues:
+  max-same-issues: 100
+  include:
+    - EXC0012
+    - EXC0014
+
 linters:
   enable:
     - bodyclose
-    - dogsled
-    - dupl
-    - errcheck
-    - errname
-    - errorlint
-    - exhaustive
     - exportloopref
-    - gochecknoinits
-    - goconst
-    - gocritic
-    - gocyclo
-    - gofmt
+    - gofumpt
     - goimports
-    - gomnd
-    - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - lll
-    - makezero
     - misspell
-    - nakedret
-    - noctx
-    - nolintlint
     - revive
     - staticcheck
-    - stylecheck
-    - testpackage
     - typecheck
-    - unconvert
-    - unparam
     - unused
     - whitespace
 
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  format: colored-line-number
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+  # sorts results by: filepath, line and column
+  sort-results: true
+
 linters-settings:
-  funlen:
-    lines: 100
-    statements: 50
+  golint:
+    min-confidence: 0.8
+
+fix: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,6 @@ linters:
     - govet
     - ineffassign
     - misspell
-    - revive
     - staticcheck
     - typecheck
     - unused

--- a/pkg/api/common/common.go
+++ b/pkg/api/common/common.go
@@ -16,6 +16,8 @@ type Tuple[T comparable, U comparable] struct {
 }
 
 func NewTuple[T comparable, U comparable](first T, second U) Tuple[T, U] {
-	return Tuple[T, U]{First: first,
-		Second: second}
+	return Tuple[T, U]{
+		First:  first,
+		Second: second,
+	}
 }

--- a/pkg/api/handlers/feature_flag_handler.go
+++ b/pkg/api/handlers/feature_flag_handler.go
@@ -503,12 +503,16 @@ func (ffh *FeatureFlagHandler) DeleteFeatureFlag(c echo.Context) error {
 	objectID, err := model.UpdateOne(
 		context.Background(),
 		bson.D{{Key: "_id", Value: featureFlagID}},
-		bson.D{{
-			Key: "$set", Value: bson.D{{
-				Key:   "deleted_at",
-				Value: primitive.NewDateTimeFromTime(time.Now().UTC()),
-			}},
-		}},
+		bson.D{
+			{
+				Key: "$set", Value: bson.D{
+					{
+						Key:   "deleted_at",
+						Value: primitive.NewDateTimeFromTime(time.Now().UTC()),
+					},
+				},
+			},
+		},
 	)
 
 	if err != nil {

--- a/pkg/api/handlers/feature_flag_handler.go
+++ b/pkg/api/handlers/feature_flag_handler.go
@@ -504,14 +504,12 @@ func (ffh *FeatureFlagHandler) DeleteFeatureFlag(c echo.Context) error {
 		context.Background(),
 		bson.D{{Key: "_id", Value: featureFlagID}},
 		bson.D{
-			{
-				Key: "$set", Value: bson.D{
-					{
-						Key:   "deleted_at",
-						Value: primitive.NewDateTimeFromTime(time.Now().UTC()),
-					},
+			{Key: "$set", Value: bson.D{
+				{
+					Key:   "deleted_at",
+					Value: primitive.NewDateTimeFromTime(time.Now().UTC()),
 				},
-			},
+			}},
 		},
 	)
 

--- a/pkg/api/handlers/feature_flag_handler.go
+++ b/pkg/api/handlers/feature_flag_handler.go
@@ -273,7 +273,6 @@ func (ffh *FeatureFlagHandler) PatchFeatureFlag(c echo.Context) error {
 }
 
 func (ffh *FeatureFlagHandler) ApproveRevision(c echo.Context) error {
-	ffh.logger.Debug("aaaaaaaaaaaaaaaaaaaaaaa")
 	userID, organizationID, err := getIDsFromContext(c)
 	if err != nil {
 		ffh.logger.Debug("Client error",
@@ -474,28 +473,12 @@ func (ffh *FeatureFlagHandler) RollbackFeatureFlagVersion(c echo.Context) error 
 }
 
 func (ffh *FeatureFlagHandler) DeleteFeatureFlag(c echo.Context) error {
-	userID, err := apiutils.GetObjectIDFromContext(c)
+	userID, organizationID, err := getIDsFromContext(c)
 	if err != nil {
 		ffh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
-			c,
-			http.StatusUnauthorized,
-			apierrors.UnauthorizedError,
-		)
-	}
-
-	organizationID, err := primitive.ObjectIDFromHex(c.Param("organizationID"))
-	if err != nil {
-		ffh.logger.Debug("Client error",
-			zap.String("cause", err.Error()),
-		)
-		return apierrors.CustomError(
-			c,
-			http.StatusBadRequest,
-			apierrors.BadRequestError,
-		)
+		return err
 	}
 
 	organizationModel := models.NewOrganizationModel(ffh.db)

--- a/pkg/api/handlers/feature_flag_handler.go
+++ b/pkg/api/handlers/feature_flag_handler.go
@@ -508,7 +508,8 @@ func (ffh *FeatureFlagHandler) DeleteFeatureFlag(c echo.Context) error {
 				Key:   "deleted_at",
 				Value: primitive.NewDateTimeFromTime(time.Now().UTC()),
 			}},
-		}})
+		}},
+	)
 
 	if err != nil {
 		ffh.logger.Debug("Server error",

--- a/pkg/api/handlers/tests/organization_handler_test.go
+++ b/pkg/api/handlers/tests/organization_handler_test.go
@@ -42,7 +42,7 @@ func (suite *OrganizationHandlerTestSuite) SetupTest() {
 	logger, _ := common.NewZapLogger()
 
 	h := handlers.NewOrganizationHandler(suite.db, logger)
-	suite.Server.POST("/organization", middlewares.AuthMiddleware(h.PostOrganization))
+	suite.Server.POST("/organizations", middlewares.AuthMiddleware(h.PostOrganization))
 }
 
 func (suite *OrganizationHandlerTestSuite) AfterTest(_, _ string) {
@@ -72,7 +72,7 @@ func (suite *OrganizationHandlerTestSuite) TestPostOrganizationHandlerSuccess() 
 		"name": "the company"
 	}`)
 
-	request := httptest.NewRequest(http.MethodPost, "/organization", bytes.NewBuffer(requestBody))
+	request := httptest.NewRequest(http.MethodPost, "/organizations", bytes.NewBuffer(requestBody))
 	request.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	request.Header.Set(echo.HeaderAuthorization, fmt.Sprintf("Bearer %s", token))
 	recorder := httptest.NewRecorder()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -80,15 +80,16 @@ func registerRoutes(app *App) {
 	userGroup.PATCH("", userHandler.PatchUser)
 
 	organizationHandler := handlers.NewOrganizationHandler(app.storage.DB(), app.logger)
-	organizationGroup := app.server.Group("/organization", middlewares.AuthMiddleware)
+	organizationGroup := app.server.Group("/organizations", middlewares.AuthMiddleware)
 	organizationGroup.POST("", organizationHandler.PostOrganization)
 
 	featureFlagHandler := handlers.NewFeatureFlagHandler(app.storage.DB(), app.logger)
-	organizationGroup.POST("/:organizationID/feature-flag", featureFlagHandler.PostFeatureFlag)
-	organizationGroup.PATCH("/:organizationID/feature-flag/featureFlagID", featureFlagHandler.PatchFeatureFlag)
-	organizationGroup.GET("/:organizationID/feature-flag", featureFlagHandler.ListFeatureFlags)
+	organizationGroup.POST("/:organizationID/feature-flags", featureFlagHandler.PostFeatureFlag)
+	organizationGroup.PATCH("/:organizationID/feature-flags/featureFlagID", featureFlagHandler.PatchFeatureFlag)
+	organizationGroup.GET("/:organizationID/feature-flags", featureFlagHandler.ListFeatureFlags)
 	organizationGroup.PATCH(
-		"/:organizationID/feature-flag/featureFlagID/revision/:revisionID",
+		"/:organizationID/feature-flags/featureFlagID/revisions/:revisionID",
 		featureFlagHandler.ApproveRevision,
 	)
+	organizationGroup.DELETE("/:organizationID/feature-flags/featureFlagID", featureFlagHandler.DeleteFeatureFlag)
 }


### PR DESCRIPTION
This PR adds an endpoint to soft delete feature flags by adding the `deleted_at` property to a specific record