### PR TITLE
feat: add x-organization header to handlers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/Roll-Play/togglelabs/pkg/api"
-	"github.com/Roll-Play/togglelabs/pkg/api/common"
 	"github.com/Roll-Play/togglelabs/pkg/config"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
 	"github.com/Roll-Play/togglelabs/pkg/storage"
 	"github.com/joho/godotenv"
 )
@@ -27,7 +27,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	logger, err := common.NewZapLogger()
+	logger, err := logger.GetInstance()
 	if err != nil {
 		log.Panic(err)
 	}

--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -1,4 +1,4 @@
-package apierrors
+package api_errors
 
 import (
 	"net/http"

--- a/pkg/api/handlers/organization_handler.go
+++ b/pkg/api/handlers/organization_handler.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"net/http"
 
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/models"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -29,9 +29,9 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 		oh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusBadRequest,
-			apierrors.BadRequestError,
+			api_errors.BadRequestError,
 		)
 	}
 
@@ -41,32 +41,32 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 		oh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusBadRequest,
-			apierrors.BadRequestError,
+			api_errors.BadRequestError,
 		)
 	}
 
-	userID, err := apiutils.GetObjectIDFromContext(c)
+	userID, err := api_utils.GetUserFromContext(c)
 	if err != nil {
 		// Should never happen but better safe than sorry
-		if errors.Is(err, apiutils.ErrNotAuthenticated) {
+		if errors.Is(err, api_utils.ErrNotAuthenticated) {
 			oh.logger.Debug("Client error",
 				zap.String("cause", err.Error()),
 			)
-			return apierrors.CustomError(
+			return api_errors.CustomError(
 				c,
 				http.StatusUnauthorized,
-				apierrors.UnauthorizedError,
+				api_errors.UnauthorizedError,
 			)
 		}
 
 		oh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
@@ -76,10 +76,10 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 		oh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
@@ -98,9 +98,9 @@ func (oh *OrganizationHandler) PostOrganization(c echo.Context) error {
 		oh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/handlers/signin_handler.go
+++ b/pkg/api/handlers/signin_handler.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/config"
 	"github.com/Roll-Play/togglelabs/pkg/models"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -34,9 +34,9 @@ func (sh *SignInHandler) PostSignIn(c echo.Context) error {
 		sh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
@@ -46,9 +46,9 @@ func (sh *SignInHandler) PostSignIn(c echo.Context) error {
 		sh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusBadRequest,
-			apierrors.BadRequestError,
+			api_errors.BadRequestError,
 		)
 	}
 
@@ -59,21 +59,21 @@ func (sh *SignInHandler) PostSignIn(c echo.Context) error {
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			sh.logger.Debug("Client error",
-				zap.String("cause", apierrors.NotFoundError),
+				zap.String("cause", api_errors.NotFoundError),
 			)
-			return apierrors.CustomError(c,
+			return api_errors.CustomError(c,
 				http.StatusNotFound,
-				apierrors.NotFoundError,
+				api_errors.NotFoundError,
 			)
 		}
 
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
@@ -81,21 +81,21 @@ func (sh *SignInHandler) PostSignIn(c echo.Context) error {
 		sh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusUnauthorized,
-			apierrors.UnauthorizedError,
+			api_errors.UnauthorizedError,
 		)
 	}
 
-	token, err := apiutils.CreateJWT(ur.ID, config.JWTExpireTime)
+	token, err := api_utils.CreateJWT(ur.ID, config.JWTExpireTime)
 	if err != nil {
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/handlers/signup_handler.go
+++ b/pkg/api/handlers/signup_handler.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/config"
 	"github.com/Roll-Play/togglelabs/pkg/models"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -38,9 +38,9 @@ func (sh *SignUpHandler) PostUser(c echo.Context) error {
 		sh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusBadRequest,
-			apierrors.BadRequestError,
+			api_errors.BadRequestError,
 		)
 	}
 
@@ -50,9 +50,9 @@ func (sh *SignUpHandler) PostUser(c echo.Context) error {
 		sh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusBadRequest,
-			apierrors.BadRequestError,
+			api_errors.BadRequestError,
 		)
 	}
 
@@ -60,11 +60,11 @@ func (sh *SignUpHandler) PostUser(c echo.Context) error {
 	_, err := model.FindByEmail(context.Background(), request.Email)
 	if err == nil {
 		sh.logger.Debug("Client error",
-			zap.String("cause", apierrors.EmailConflictError),
+			zap.String("cause", api_errors.EmailConflictError),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusConflict,
-			apierrors.EmailConflictError,
+			api_errors.EmailConflictError,
 		)
 	}
 
@@ -73,9 +73,9 @@ func (sh *SignUpHandler) PostUser(c echo.Context) error {
 		sh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
@@ -84,20 +84,20 @@ func (sh *SignUpHandler) PostUser(c echo.Context) error {
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
-	token, err := apiutils.CreateJWT(objectID, config.JWTExpireTime)
+	token, err := api_utils.CreateJWT(objectID, config.JWTExpireTime)
 	if err != nil {
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 	sh.logger.Debug("Created user",

--- a/pkg/api/handlers/sso_handler.go
+++ b/pkg/api/handlers/sso_handler.go
@@ -9,10 +9,10 @@ import (
 	"os"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/config"
 	"github.com/Roll-Play/togglelabs/pkg/models"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
@@ -23,16 +23,16 @@ type SsoHandler struct {
 	oauthConfig *oauth2.Config
 	db          *mongo.Database
 	logger      *zap.Logger
-	httpClient  apiutils.BaseHTTPClient
-	oauthClient apiutils.OAuthClient
+	httpClient  api_utils.BaseHTTPClient
+	oauthClient api_utils.OAuthClient
 }
 
 func NewSsoHandler(
 	db *mongo.Database,
 	oauthConfig *oauth2.Config,
 	logger *zap.Logger,
-	httpClient apiutils.BaseHTTPClient,
-	oauthClient apiutils.OAuthClient,
+	httpClient api_utils.BaseHTTPClient,
+	oauthClient api_utils.OAuthClient,
 ) *SsoHandler {
 	return &SsoHandler{
 		oauthConfig: oauthConfig,
@@ -64,10 +64,10 @@ func (sh *SsoHandler) Callback(c echo.Context) error {
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 	userData := new(models.UserRecord)
@@ -76,25 +76,25 @@ func (sh *SsoHandler) Callback(c echo.Context) error {
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
 	model := models.NewUserModel(sh.db)
 	foundRecord, err := model.FindByEmail(context.Background(), userData.Email)
 	if err == nil {
-		token, err := apiutils.CreateJWT(foundRecord.ID, config.JWTExpireTime)
+		token, err := api_utils.CreateJWT(foundRecord.ID, config.JWTExpireTime)
 		if err != nil {
 			sh.logger.Debug("Server error",
 				zap.String("cause", err.Error()),
 			)
-			return apierrors.CustomError(
+			return api_errors.CustomError(
 				c,
 				http.StatusInternalServerError,
-				apierrors.InternalServerError,
+				api_errors.InternalServerError,
 			)
 		}
 
@@ -112,22 +112,22 @@ func (sh *SsoHandler) Callback(c echo.Context) error {
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
-	token, err := apiutils.CreateJWT(objectID, config.JWTExpireTime)
+	token, err := api_utils.CreateJWT(objectID, config.JWTExpireTime)
 	if err != nil {
 		sh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/handlers/tests/organization_handler_test.go
+++ b/pkg/api/handlers/tests/organization_handler_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Roll-Play/togglelabs/pkg/api/common"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/tests/fixtures"
 	"github.com/Roll-Play/togglelabs/pkg/api/middlewares"
 	"github.com/Roll-Play/togglelabs/pkg/config"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
 	"github.com/Roll-Play/togglelabs/pkg/models"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	testutils "github.com/Roll-Play/togglelabs/pkg/utils/test_utils"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +39,7 @@ func (suite *OrganizationHandlerTestSuite) SetupTest() {
 	suite.db = client.Database(config.TestDBName)
 	suite.Server = echo.New()
 
-	logger, _ := common.NewZapLogger()
+	logger, _ := logger.NewZapLogger()
 
 	h := handlers.NewOrganizationHandler(suite.db, logger)
 	suite.Server.POST("/organizations", middlewares.AuthMiddleware(h.PostOrganization))
@@ -65,7 +65,7 @@ func (suite *OrganizationHandlerTestSuite) TestPostOrganizationHandlerSuccess() 
 	model := models.NewOrganizationModel(suite.db)
 
 	user := fixtures.CreateUser("", "", "", "", suite.db)
-	token, err := apiutils.CreateJWT(user.ID, time.Second*120)
+	token, err := api_utils.CreateJWT(user.ID, time.Second*120)
 	assert.NoError(t, err)
 
 	requestBody := []byte(`{

--- a/pkg/api/handlers/tests/signin_handler_test.go
+++ b/pkg/api/handlers/tests/signin_handler_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/tests/fixtures"
 	"github.com/Roll-Play/togglelabs/pkg/config"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
 	testutils "github.com/Roll-Play/togglelabs/pkg/utils/test_utils"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ func (suite *SignInHandlerTestSuite) SetupTest() {
 
 	suite.db = client.Database(config.TestDBName)
 	suite.Server = echo.New()
-	logger, _ := common.NewZapLogger()
+	logger, _ := logger.NewZapLogger()
 	h := handlers.NewSignInHandler(suite.db, logger)
 	suite.Server.POST("/signin", h.PostSignIn)
 }
@@ -91,13 +92,13 @@ func (suite *SignInHandlerTestSuite) TestSignInHandlerNotFound() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response apierrors.Error
+	var response api_errors.Error
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, apierrors.Error{
+	assert.Equal(t, api_errors.Error{
 		Error:   http.StatusText(http.StatusNotFound),
-		Message: apierrors.NotFoundError,
+		Message: api_errors.NotFoundError,
 	}, response)
 }
 
@@ -116,13 +117,13 @@ func (suite *SignInHandlerTestSuite) TestSignInHandlerUnauthorized() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response apierrors.Error
+	var response api_errors.Error
 
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, apierrors.Error{
+	assert.Equal(t, api_errors.Error{
 		Error:   http.StatusText(http.StatusUnauthorized),
-		Message: apierrors.UnauthorizedError,
+		Message: api_errors.UnauthorizedError,
 	}, response)
 }
 

--- a/pkg/api/handlers/tests/signup_handler_test.go
+++ b/pkg/api/handlers/tests/signup_handler_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/tests/fixtures"
 	"github.com/Roll-Play/togglelabs/pkg/config"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
 	"github.com/Roll-Play/togglelabs/pkg/models"
 	testutils "github.com/Roll-Play/togglelabs/pkg/utils/test_utils"
 	"github.com/labstack/echo/v4"
@@ -36,7 +37,7 @@ func (suite *SignUpHandlerTestSuite) SetupTest() {
 
 	suite.db = client.Database(config.TestDBName)
 	suite.Server = echo.New()
-	logger, _ := common.NewZapLogger()
+	logger, _ := logger.NewZapLogger()
 	h := handlers.NewSignUpHandler(suite.db, logger)
 	suite.Server.POST("/signup", h.PostUser)
 }
@@ -96,13 +97,13 @@ func (suite *SignUpHandlerTestSuite) TestSignUpHandlerUnsuccessful() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response apierrors.Error
+	var response api_errors.Error
 
 	assert.Equal(t, http.StatusConflict, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, response, apierrors.Error{
+	assert.Equal(t, response, api_errors.Error{
 		Error:   http.StatusText(http.StatusConflict),
-		Message: apierrors.EmailConflictError,
+		Message: api_errors.EmailConflictError,
 	})
 }
 

--- a/pkg/api/handlers/tests/sso_handler_test.go
+++ b/pkg/api/handlers/tests/sso_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Roll-Play/togglelabs/pkg/api/common"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/tests/fixtures"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
 	"github.com/Roll-Play/togglelabs/pkg/models"
 	testutils "github.com/Roll-Play/togglelabs/pkg/utils/test_utils"
 	"github.com/joho/godotenv"
@@ -79,7 +80,7 @@ func (suite *SsoTestSuite) TestSSoHandlerNewUserSuccess() {
 	urlq.Add("code", "code")
 	request.URL.RawQuery = urlq.Encode()
 
-	logger, _ := common.NewZapLogger()
+	logger, _ := logger.NewZapLogger()
 
 	h := handlers.NewSsoHandler(suite.db, &oauth2.Config{}, logger, &fixtures.MockHTTPClient{}, mockOAuthClient)
 	assert.NotNil(t, h)
@@ -117,7 +118,7 @@ func (suite *SsoTestSuite) TestSSoHandlerExistingUserSuccess() {
 	urlq.Add("code", "code")
 	request.URL.RawQuery = urlq.Encode()
 
-	logger, _ := common.NewZapLogger()
+	logger, _ := logger.NewZapLogger()
 
 	h := handlers.NewSsoHandler(suite.db, &oauth2.Config{}, logger, &fixtures.MockHTTPClient{}, mockOAuthClient)
 	suite.Server.GET("/callback", h.Callback)

--- a/pkg/api/handlers/tests/user_handler_test.go
+++ b/pkg/api/handlers/tests/user_handler_test.go
@@ -10,14 +10,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Roll-Play/togglelabs/pkg/api/common"
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers/tests/fixtures"
 	"github.com/Roll-Play/togglelabs/pkg/api/middlewares"
 	"github.com/Roll-Play/togglelabs/pkg/config"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
 	"github.com/Roll-Play/togglelabs/pkg/models"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	testutils "github.com/Roll-Play/togglelabs/pkg/utils/test_utils"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -40,7 +40,7 @@ func (suite *UserHandlerTestSuite) SetupTest() {
 
 	suite.db = client.Database(config.TestDBName)
 	suite.Server = echo.New()
-	logger, _ := common.NewZapLogger()
+	logger, _ := logger.NewZapLogger()
 	h := handlers.NewUserHandler(suite.db, logger)
 	suite.Server.PATCH("/user", middlewares.AuthMiddleware(h.PatchUser))
 }
@@ -73,7 +73,7 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerSuccess() {
 	requestBody, err := json.Marshal(patchInfo)
 	assert.NoError(t, err)
 
-	token, err := apiutils.CreateJWT(user.ID, time.Second*120)
+	token, err := api_utils.CreateJWT(user.ID, time.Second*120)
 
 	assert.NoError(t, err)
 
@@ -104,7 +104,7 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerNotFound() {
 	requestBody, err := json.Marshal(patchInfo)
 	assert.NoError(t, err)
 
-	token, err := apiutils.CreateJWT(primitive.NewObjectID(), time.Second*120)
+	token, err := api_utils.CreateJWT(primitive.NewObjectID(), time.Second*120)
 	assert.NoError(t, err)
 
 	request := httptest.NewRequest(http.MethodPatch, "/user", bytes.NewBuffer(requestBody))
@@ -113,13 +113,13 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerNotFound() {
 	recorder := httptest.NewRecorder()
 
 	suite.Server.ServeHTTP(recorder, request)
-	var response apierrors.Error
+	var response api_errors.Error
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, apierrors.Error{
+	assert.Equal(t, api_errors.Error{
 		Error:   http.StatusText(http.StatusNotFound),
-		Message: apierrors.NotFoundError,
+		Message: api_errors.NotFoundError,
 	}, response)
 }
 
@@ -136,7 +136,7 @@ func (suite *UserHandlerTestSuite) TestUserPatchHandlerOnlyChangesAllowedFields(
 			"email": "new@email.mail"
 		}`)
 
-	token, err := apiutils.CreateJWT(user.ID, time.Second*120)
+	token, err := api_utils.CreateJWT(user.ID, time.Second*120)
 	assert.NoError(t, err)
 	request := httptest.NewRequest(http.MethodPatch, "/user", bytes.NewBuffer(requestBody))
 	request.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/pkg/api/handlers/user_handler.go
+++ b/pkg/api/handlers/user_handler.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"net/http"
 
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
 	"github.com/Roll-Play/togglelabs/pkg/models"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/bson"
@@ -47,9 +47,9 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 		uh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusBadRequest,
-			apierrors.BadRequestError,
+			api_errors.BadRequestError,
 		)
 	}
 
@@ -59,34 +59,34 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 		uh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusBadRequest,
-			apierrors.BadRequestError,
+			api_errors.BadRequestError,
 		)
 	}
 
-	userID, err := apiutils.GetObjectIDFromContext(c)
+	userID, err := api_utils.GetUserFromContext(c)
 	if err != nil {
-		log.Println(apiutils.HandlerErrorLogMessage(err, c))
+		log.Println(api_utils.HandlerErrorLogMessage(err, c))
 		// Should never happen but better safe than sorry
-		if errors.Is(err, apiutils.ErrNotAuthenticated) {
+		if errors.Is(err, api_utils.ErrNotAuthenticated) {
 			uh.logger.Debug("Client error",
 				zap.String("cause", err.Error()),
 			)
-			return apierrors.CustomError(
+			return api_errors.CustomError(
 				c,
 				http.StatusUnauthorized,
-				apierrors.UnauthorizedError,
+				api_errors.UnauthorizedError,
 			)
 		}
 
 		uh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(
+		return api_errors.CustomError(
 			c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 
@@ -96,9 +96,9 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 		uh.logger.Debug("Client error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusNotFound,
-			apierrors.NotFoundError,
+			api_errors.NotFoundError,
 		)
 	}
 
@@ -115,9 +115,9 @@ func (uh *UserHandler) PatchUser(c echo.Context) error {
 		uh.logger.Debug("Server error",
 			zap.String("cause", err.Error()),
 		)
-		return apierrors.CustomError(c,
+		return api_errors.CustomError(c,
 			http.StatusInternalServerError,
-			apierrors.InternalServerError,
+			api_errors.InternalServerError,
 		)
 	}
 

--- a/pkg/api/middlewares/auth_middleware.go
+++ b/pkg/api/middlewares/auth_middleware.go
@@ -6,11 +6,13 @@ import (
 	"net/http"
 	"strings"
 
-	apierrors "github.com/Roll-Play/togglelabs/pkg/api/error"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/golang-jwt/jwt"
 	"github.com/labstack/echo/v4"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap"
 )
 
 var ErrMissingAuthHeader = errors.New("missing authorization header")
@@ -19,11 +21,13 @@ var ErrInvalidToken = errors.New("invalid token")
 
 func AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		authHeader := c.Request().Header.Get("Authorization")
+		logger, _ := logger.GetInstance()
+		authHeader := c.Request().Header.Get(echo.HeaderAuthorization)
 
 		if authHeader == "" {
-			log.Println(apiutils.HandlerErrorLogMessage(ErrMissingAuthHeader, c))
-			return c.JSON(http.StatusUnauthorized, apierrors.Error{
+			logger.Debug("Client error",
+				zap.String("cause", "missing Authorization header"))
+			return c.JSON(http.StatusUnauthorized, api_errors.Error{
 				Error:   "missing Authorization header",
 				Message: http.StatusText(http.StatusUnauthorized),
 			})
@@ -34,15 +38,19 @@ func AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			secretKey := []byte("your-secret-key")
 
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-				log.Println(apiutils.HandlerErrorLogMessage(ErrInvalidSignMethod, c))
+
+				logger.Debug("Client error",
+					zap.String("cause", ErrInvalidSignMethod.Error()))
 				return nil, ErrInvalidSignMethod
 			}
 			return secretKey, nil
 		})
 
 		if err != nil {
-			log.Println(apiutils.HandlerErrorLogMessage(err, c))
-			return c.JSON(http.StatusUnauthorized, apierrors.Error{
+
+			logger.Debug("Client error",
+				zap.String("cause", err.Error()))
+			return c.JSON(http.StatusUnauthorized, api_errors.Error{
 				Error:   ErrInvalidToken.Error(),
 				Message: http.StatusText(http.StatusUnauthorized),
 			})
@@ -52,21 +60,19 @@ func AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			sub, _ := claims["sub"].(string)
 			userID, err := primitive.ObjectIDFromHex(sub)
 			if err != nil {
-				log.Println(apiutils.HandlerErrorLogMessage(err, c))
-				return c.JSON(http.StatusUnauthorized, apierrors.Error{
+				log.Println(api_utils.HandlerErrorLogMessage(err, c))
+				return c.JSON(http.StatusUnauthorized, api_errors.Error{
 					Error:   "invalid token sub",
 					Message: http.StatusText(http.StatusUnauthorized),
 				})
 			}
 
-			c.Set("user", apiutils.ContextUser{
-				ID: userID,
-			})
+			c.Set("user", userID.Hex())
 			return next(c)
 		}
 
-		log.Println(apiutils.HandlerErrorLogMessage(ErrInvalidToken, c))
-		return c.JSON(http.StatusUnauthorized, apierrors.Error{
+		log.Println(api_utils.HandlerErrorLogMessage(ErrInvalidToken, c))
+		return c.JSON(http.StatusUnauthorized, api_errors.Error{
 			Error:   ErrInvalidToken.Error(),
 			Message: http.StatusText(http.StatusUnauthorized),
 		})

--- a/pkg/api/middlewares/auth_middleware.go
+++ b/pkg/api/middlewares/auth_middleware.go
@@ -47,7 +47,6 @@ func AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		})
 
 		if err != nil {
-
 			logger.Debug("Client error",
 				zap.String("cause", err.Error()))
 			return c.JSON(http.StatusUnauthorized, api_errors.Error{

--- a/pkg/api/middlewares/auth_middleware.go
+++ b/pkg/api/middlewares/auth_middleware.go
@@ -38,7 +38,6 @@ func AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			secretKey := []byte("your-secret-key")
 
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-
 				logger.Debug("Client error",
 					zap.String("cause", ErrInvalidSignMethod.Error()))
 				return nil, ErrInvalidSignMethod

--- a/pkg/api/middlewares/organization_middleware.go
+++ b/pkg/api/middlewares/organization_middleware.go
@@ -1,0 +1,43 @@
+package middlewares
+
+import (
+	"net/http"
+
+	api_errors "github.com/Roll-Play/togglelabs/pkg/api/error"
+	"github.com/Roll-Play/togglelabs/pkg/logger"
+	"github.com/labstack/echo/v4"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap"
+)
+
+const XOrganizationHeader = "X-organization"
+
+func OrganizationMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		logger, _ := logger.GetInstance()
+		organizationHeader := c.Request().Header.Get(XOrganizationHeader)
+
+		if organizationHeader == "" {
+			logger.Debug("Missing organization header")
+			return api_errors.CustomError(
+				c,
+				http.StatusBadRequest,
+				api_errors.BadRequestError,
+			)
+		}
+
+		organizationID, err := primitive.ObjectIDFromHex(organizationHeader)
+		if err != nil {
+			logger.Debug("Client error",
+				zap.String("cause", err.Error()))
+			return api_errors.CustomError(
+				c,
+				http.StatusBadRequest,
+				api_errors.BadRequestError,
+			)
+		}
+
+		c.Set("organization", organizationID.Hex())
+		return next(c)
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Roll-Play/togglelabs/pkg/api/handlers"
 	"github.com/Roll-Play/togglelabs/pkg/api/middlewares"
 	"github.com/Roll-Play/togglelabs/pkg/storage"
-	apiutils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
+	api_utils "github.com/Roll-Play/togglelabs/pkg/utils/api_utils"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -63,8 +63,8 @@ func registerRoutes(app *App) {
 		app.storage.DB(),
 		oauthConfig,
 		app.logger,
-		&apiutils.HTTPClient{},
-		apiutils.NewOAuthClient(oauthConfig),
+		&api_utils.HTTPClient{},
+		api_utils.NewOAuthClient(oauthConfig),
 	)
 	app.server.POST("/oauth", ssoHandler.Signin)
 	app.server.GET("/callback", ssoHandler.Callback)
@@ -80,20 +80,20 @@ func registerRoutes(app *App) {
 	userGroup.PATCH("", userHandler.PatchUser)
 
 	organizationHandler := handlers.NewOrganizationHandler(app.storage.DB(), app.logger)
-	organizationGroup := app.server.Group("/organizations", middlewares.AuthMiddleware)
-	organizationGroup.POST("", organizationHandler.PostOrganization)
+	app.server.POST("/organizations", middlewares.AuthMiddleware(organizationHandler.PostOrganization))
 
 	featureFlagHandler := handlers.NewFeatureFlagHandler(app.storage.DB(), app.logger)
-	organizationGroup.POST("/:organizationID/feature-flags", featureFlagHandler.PostFeatureFlag)
-	organizationGroup.PATCH("/:organizationID/feature-flags/featureFlagID", featureFlagHandler.PatchFeatureFlag)
-	organizationGroup.GET("/:organizationID/feature-flags", featureFlagHandler.ListFeatureFlags)
-	organizationGroup.PATCH(
-		"/:organizationID/feature-flags/featureFlagID/revisions/:revisionID",
+	featureGroup := app.server.Group("/features", middlewares.AuthMiddleware, middlewares.OrganizationMiddleware)
+	featureGroup.POST("", featureFlagHandler.PostFeatureFlag)
+	featureGroup.GET("", featureFlagHandler.ListFeatureFlags)
+	featureGroup.PATCH("/:featureFlagID", featureFlagHandler.PatchFeatureFlag)
+	featureGroup.PATCH(
+		"/:featureFlagID/revisions/:revisionID",
 		featureFlagHandler.ApproveRevision,
 	)
-	organizationGroup.DELETE("/:organizationID/feature-flags/featureFlagID", featureFlagHandler.DeleteFeatureFlag)
-	organizationGroup.PATCH(
-		"/:organizationID/feature-flags/:featureFlagID/rollback",
+	featureGroup.DELETE("/:featureFlagID", featureFlagHandler.DeleteFeatureFlag)
+	featureGroup.PATCH(
+		"/:featureFlagID/rollback",
 		featureFlagHandler.RollbackFeatureFlagVersion,
 	)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,10 +1,15 @@
-package common
+package logger
 
 import (
+	"sync"
+
 	"github.com/Roll-Play/togglelabs/pkg/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+var logger *zap.Logger
+var lock = &sync.Mutex{}
 
 func NewZapLogger() (*zap.Logger, error) {
 	var level zapcore.Level
@@ -38,5 +43,21 @@ func NewZapLogger() (*zap.Logger, error) {
 		return nil, err
 	}
 
+	return logger, nil
+}
+
+func GetInstance() (*zap.Logger, error) {
+	if logger != nil {
+		return logger, nil
+	}
+
+	lock.Lock()
+	defer lock.Unlock()
+	newLogger, err := NewZapLogger()
+	if err != nil {
+		return nil, err
+	}
+
+	logger = newLogger
 	return logger, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,7 +16,7 @@ type MongoStorage struct {
 }
 
 var lock = &sync.Mutex{}
-var storeSingleton *MongoStorage
+var store *MongoStorage
 
 func newMongoStorage(ctx context.Context) (*MongoStorage, error) {
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(os.Getenv("DATABASE_URL")))
@@ -66,17 +66,18 @@ func (ms *MongoStorage) Init() error {
 }
 
 func GetInstance() (*MongoStorage, error) {
-	if storeSingleton != nil {
-		return storeSingleton, nil
+	if store != nil {
+		return store, nil
 	}
 
 	lock.Lock()
 	defer lock.Unlock()
 
-	storeSingleton, err := newMongoStorage(context.Background())
+	newStore, err := newMongoStorage(context.Background())
 	if err != nil {
 		return nil, err
 	}
 
-	return storeSingleton, nil
+	store = newStore
+	return store, nil
 }

--- a/pkg/utils/api_utils/jwt.go
+++ b/pkg/utils/api_utils/jwt.go
@@ -1,4 +1,4 @@
-package apiutils
+package api_utils
 
 import (
 	"os"

--- a/pkg/utils/test_utils/test_utils.go
+++ b/pkg/utils/test_utils/test_utils.go
@@ -1,4 +1,4 @@
-package testutils
+package test_utils
 
 import (
 	"github.com/labstack/echo/v4"


### PR DESCRIPTION
Adds `X-organization` header parsing to the handlers removing the need to prefix the URIs with `/organizations/:organizationID`